### PR TITLE
Set the common part of an item's data_dir in the pipeline

### DIFF
--- a/seesaw/item.py
+++ b/seesaw/item.py
@@ -46,7 +46,7 @@ class Item(object):
         self.prepare_data_directory()
 
     def prepare_data_directory(self):
-        dirname = os.path.join(self.pipeline.cwd, "data/%s" % self.item_id)
+        dirname = os.path.join(self.pipeline.data_dir, self.item_id)
         self["data_dir"] = dirname
         if os.path.isdir(dirname):
             shutil.rmtree(dirname)

--- a/seesaw/pipeline.py
+++ b/seesaw/pipeline.py
@@ -19,6 +19,7 @@ class Pipeline(object):
     '''
     def __init__(self, *tasks):
         self.cwd = os.getcwd()
+        self.data_dir = os.path.join(self.cwd, "data")
         self.on_start_item = Event()
         self.on_complete_item = Event()
         self.on_fail_item = Event()


### PR DESCRIPTION
In Seesaw, while all fetch items have their own scratch directories, those scratch directories all share a common non-/ parent.  That's fine. However, prior to this commit, that scratch directory was only accessible when you had access to an item.

This can make life awkward in some cases.  The motivating example is Archive Team's ArchiveBot[1], which will have a background task that periodically reports on memory and disk space usage.  It's difficult to get the latter unless it's visible at pipeline scope.  (The alternative is to install one reporting task per item, but that shouldn't be necessary -- there's one pipeline and one scratch directory.)

This commit moves the common scratch directory up to the pipeline, where it can be more easily accessed.

[1] https://github.com/ArchiveTeam/ArchiveBot
