### PR TITLE
Add on_cleanup event to pipeline

### DIFF
--- a/seesaw/pipeline.py
+++ b/seesaw/pipeline.py
@@ -25,6 +25,7 @@ class Pipeline(object):
         self.on_fail_item = Event()
         self.on_cancel_item = Event()
         self.on_finish_item = Event()
+        self.on_cleanup = Event()
         self.project = None
 
         self.items_in_pipeline = set()

--- a/seesaw/runner.py
+++ b/seesaw/runner.py
@@ -155,6 +155,7 @@ class SimpleRunner(Runner):
     def start(self):
         Runner.start(self)
         ioloop.IOLoop.instance().start()
+        self.pipeline.on_cleanup()
 
     def _stop_ioloop(self, ignored):
         ioloop.IOLoop.instance().stop()

--- a/seesaw/runner_test.py
+++ b/seesaw/runner_test.py
@@ -1,0 +1,23 @@
+from seesaw.pipeline import Pipeline
+from seesaw.runner import SimpleRunner
+from seesaw.task import PrintItem, SimpleTask
+from seesaw.test_base import BaseTestCase
+
+class RunnerTest(BaseTestCase):
+    def setUp(self):
+        super(RunnerTest, self).setUp()
+
+        self.cleanup_calls = 0
+
+    def test_runner_does_pipeline_cleanup_before_shutdown(self):
+        pipeline = Pipeline(PrintItem())
+        runner = SimpleRunner(pipeline, max_items=1)
+
+        def cleanup():
+            self.cleanup_calls += 1
+
+        pipeline.on_cleanup += cleanup
+        runner.start()
+
+        self.assertEqual(1, self.cleanup_calls)
+        self.assertEqual(1, runner.item_count)


### PR DESCRIPTION
Some pipelines (i.e. ArchiveBot's) run threads that, if not terminated, will prevent the usual `touch STOP` mechanism from stopping a pipeline*.  Such pipelines need a way to be told "hey, the runner's about to stop, so do whatever you need to do to prepare for shutdown".  

This commit adds such an event and makes SimpleRunner (i.e. what most Seesaw sessions use) trigger it.

(Because this event requires runner-pipeline interaction, other Runner subclasses will have to be sure that they trigger it.)

I have only added this event to the `python3/development` branch because it's currently only really of use to ArchiveBot, and ArchiveBot uses the aforementioned branch.  It should not be too difficult to backport the change if that is desired.

*: https://github.com/ArchiveTeam/ArchiveBot/compare/pipeline-next%5E%5E%5E...pipeline-next
