### PR TITLE
Introduce Item.get

### DIFF
--- a/seesaw/item.py
+++ b/seesaw/item.py
@@ -21,7 +21,7 @@ class Item(object):
         you know what you are doing.
     '''
     def __init__(self, pipeline, item_id, item_number, properties=None,
-                 keep_data=False):
+                 keep_data=False, prepare_data_directory=True):
         self.pipeline = pipeline
         self.item_id = item_id
         self.item_number = item_number
@@ -45,7 +45,8 @@ class Item(object):
         self.on_fail = Event()
         self.on_finish = Event()
 
-        self.prepare_data_directory()
+        if prepare_data_directory:
+            self.prepare_data_directory()
 
     def prepare_data_directory(self):
         dirname = os.path.join(self.pipeline.data_dir, self.item_id)

--- a/seesaw/item_test.py
+++ b/seesaw/item_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from seesaw.item import Item
+
+class MockPipeline(object):
+    pass
+
+class ItemTest(unittest.TestCase):
+    def setUp(self):
+        self.item = Item(MockPipeline(), 'FakeID', 1, prepare_data_directory=False)
+
+    def test_get_returns_none_for_undefined_keys(self):
+        self.assertEquals(None, self.item.get('undefined_key'))
+
+    def test_get_returns_property(self):
+        self.item['foo'] = 'bar'
+
+        self.assertEquals('bar', self.item.get('foo'))


### PR DESCRIPTION
This mimics the behavior of dict.get.  It can be useful for contexts where
1. `None` is an acceptable "key does not exist" value and
2. we don't want to do a bunch of `if key in item` checks.
