### PR TITLE
Add overall task indicators/counters to the top of the project status page

### DIFF
--- a/seesaw/public/index.html
+++ b/seesaw/public/index.html
@@ -79,6 +79,10 @@
 
   <div class="content" id="view-current-project">
     <div id="project-header"></div>
+    <div id="task-summary">
+        <h2>Task Status Summary</h2>
+        <ol class="tasks"></ol>
+    </div>
     <div id="items"></div>
   </div>
 

--- a/seesaw/public/script.js
+++ b/seesaw/public/script.js
@@ -153,6 +153,16 @@ $(function() {
                        $(itemTask).data('index'),
                        $('#item-' + msg.item_id + ' li').length);
     }
+    
+    //Re-calculate the totals for the main 'task summary' area
+    if(msg.new_status == "running") {
+        newTaskTotal = parseInt($('#task-summary ol.tasks li.task-' + msg.task_id + ' span.s').html()) + 1;
+    } else {
+        newTaskTotal = parseInt($('#task-summary ol.tasks li.task-' + msg.task_id + ' span.s').html()) - 1;
+    }
+    
+    $('#task-summary ol.tasks li.task-' + msg.task_id + ' span.s').text(newTaskTotal);
+    
   });
 
   registerEvent('item.update_name', function(msg) { // item_id, new_name
@@ -401,8 +411,14 @@ $(function() {
       span.appendChild(document.createTextNode(taskStatusChars[task.status] || ''));
       li.appendChild(span);
       ol.appendChild(li);
+      if($('#task-summary .task-' + task.id).length == 0) {
+        //Add new item to master task list
+        $('#task-summary ol.tasks').append('<li class="task-' + task.id + '">' + task.name + ' <span class="s">0</span></li>');
+      }
       if (task.status == 'running') {
         currentTask = i+1;
+        newTaskTotal = parseInt($('#task-summary ol.tasks li.task-' + task.id + ' span.s').html()) + 1;
+        $('#task-summary ol.tasks li.task-' + task.id + ' span.s').text(newTaskTotal);
       }
     }
     itemDiv.appendChild(ol);

--- a/seesaw/public/style.css
+++ b/seesaw/public/style.css
@@ -199,6 +199,27 @@ table.time-left td span {
   border-radius: 5px;
 }
 
+
+#task-summary {
+  position: relative;
+  margin: 10px 5px 10px 5px;
+}
+#task-summary h2 {
+  font-size: 130%;
+}
+#task-summary ol.tasks {
+  width: 100% !important;
+  float: none !important;
+}
+#task-summary ol.tasks li {
+  display: inline-block;
+  margin-right: 10px !important;
+}
+#task-summary ol.tasks li span.s {
+  margin-left: 20px;
+}
+
+
 #items {
   position: relative;
   margin: 0 10px 40px 10px;
@@ -266,7 +287,8 @@ table.time-left td span {
 .item.closed div.status {
   display: none;
 }
-.item ol.tasks {
+.item ol.tasks,
+#task-summary ol.tasks {
   display: block;
   float: left;
   margin: 0 3px 0 5px;
@@ -278,7 +300,8 @@ table.time-left td span {
 .item.closed ol.tasks {
   display: none;
 }
-.item ol.tasks li {
+.item ol.tasks li,
+#task-summary ol.tasks li {
   position: relative;
   background: #eff6ee;
   color: #94c58b;
@@ -287,11 +310,13 @@ table.time-left td span {
   vertical-align: middle;
   border-radius: 4px;
 }
-.item ol.tasks li.completed {
+.item ol.tasks li.completed,
+#task-summary ol.tasks li.completed {
   background: #a1cc99;
   color: #326827;
 }
-.item ol.tasks li.running {
+.item ol.tasks li.running,
+#task-summary ol.tasks li {
   background: #459B34;
   color: #fff;
 }


### PR DESCRIPTION
This pull request adds a series of indicators/counters to the top of the status page, showing a counter for how many items are at each task. E.g. it shows 2 items at "Scraper" and 1 at "Upload".
