### PR TITLE
Add stop requested/canceled events to pipeline

### DIFF
--- a/seesaw/pipeline.py
+++ b/seesaw/pipeline.py
@@ -26,6 +26,8 @@ class Pipeline(object):
         self.on_cancel_item = Event()
         self.on_finish_item = Event()
         self.on_cleanup = Event()
+        self.on_stop_requested = Event()
+        self.on_stop_canceled = Event()
         self.project = None
 
         self.items_in_pipeline = set()

--- a/seesaw/runner.py
+++ b/seesaw/runner.py
@@ -59,12 +59,14 @@ class Runner(object):
         print("Stopping when current tasks are completed...")
         self.stop_flag = True
         self.pipeline.cancel_items()
+        self.pipeline.on_stop_requested()
         self.initial_stop_file_mtime = self.stop_file_mtime()
         self.on_status(self, "stopping")
 
     def keep_running(self):
         print("Keep running...")
         self.stop_flag = False
+        self.pipeline.on_stop_canceled()
         self.initial_stop_file_mtime = self.stop_file_mtime()
         self.on_status(self, "running")
 

--- a/seesaw/runner_test.py
+++ b/seesaw/runner_test.py
@@ -8,6 +8,8 @@ class RunnerTest(BaseTestCase):
         super(RunnerTest, self).setUp()
 
         self.cleanup_calls = 0
+        self.stop_canceled_calls = 0
+        self.stop_requested_calls = 0
 
     def test_runner_does_pipeline_cleanup_before_shutdown(self):
         pipeline = Pipeline(PrintItem())
@@ -21,3 +23,30 @@ class RunnerTest(BaseTestCase):
 
         self.assertEqual(1, self.cleanup_calls)
         self.assertEqual(1, runner.item_count)
+
+    def test_runner_signals_pipeline_on_stop(self):
+        pipeline = Pipeline(PrintItem())
+        runner = SimpleRunner(pipeline, max_items=1)
+
+        def stop_requested():
+            self.stop_requested_calls += 1
+
+        pipeline.on_stop_requested += stop_requested
+        runner.start()
+        runner.stop_gracefully()
+
+        self.assertEqual(1, self.stop_requested_calls)
+
+    def test_runner_signals_pipeline_when_stop_canceled(self):
+        pipeline = Pipeline(PrintItem())
+        runner = SimpleRunner(pipeline, max_items=1)
+
+        def stop_canceled():
+            self.stop_canceled_calls += 1
+
+        pipeline.on_stop_canceled += stop_canceled
+        runner.start()
+        runner.stop_gracefully()
+        runner.keep_running()
+
+        self.assertEqual(1, self.stop_canceled_calls)


### PR DESCRIPTION
Motivation: ArchiveBot's pipeline dashboard shows a list of pipelines, but it cannot yet show which pipelines have been `touch STOP`ed: the Seesaw pipeline runner does not provide the pipeline with this information.

This pull request adds events to the pipeline that are triggered when a stop is requested and when a requested stop is canceled.  (The latter appears to only occur via the Warrior interface, but in the future we can wire up e.g. `rm STOP` to also do that.)
