### PR TITLE
Use window.location.protocol instead of hardcoding http

### DIFF
--- a/seesaw/public/script.js
+++ b/seesaw/public/script.js
@@ -1,5 +1,5 @@
 $(function() {
-  var conn = new SockJS('http://' + window.location.host);
+  var conn = new SockJS(window.location.protocol + '//' + window.location.host);
   var multiProject = false;
   var instanceID = null;
   var eventCallbacks = {};

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ package_data = {
         'public/index.html',
         'public/*.js',
         'public/*.css',
+        'public/*.png',
         'templates/*.html'
     ]
 }


### PR DESCRIPTION
If your instance of warrior is being proxied with ssl the web interface
will break because this script expects to create a websocket over http.
This can be fixed by using window.location.protocol which will return
what protocol you are visiting the web interface(http or https)