### PR TITLE
Add auto update for runners and warriors

### DIFF
--- a/run-au-pipeline
+++ b/run-au-pipeline
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+export WRAPPED_RUNNER=1
+
+pull_run_pipeline()
+{
+rm UPDATE
+echo "Attempting pipeline update."
+git pull && run-pipeline $@
+}
+
+run-pipeline $@
+
+while [ -f UPDATE]
+do
+pull_run_pipeline $@
+done

--- a/seesaw/script/run_pipeline.py
+++ b/seesaw/script/run_pipeline.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from argparse import ArgumentParser
 import itertools
-import os.path
+import os
 import re
 import subprocess
 import sys
@@ -164,7 +164,12 @@ def attach_git_scheduler(runner):
 
 
 def main():
-    parser = ArgumentParser(description="Run the pipeline")
+    global runner
+    
+    if os.getenv("WRAPPED_RUNNER") == "1":
+        parser = ArgumentParser(prog="run-au-pipeline", description="Run the pipeline with automatic updates")
+    else:
+        parser = ArgumentParser(description="Run the pipeline")
     parser.add_argument("pipeline", metavar="PIPELINE", type=str,
                         help="the pipeline file")
     parser.add_argument("downloader", metavar="DOWNLOADER", type=str,
@@ -309,6 +314,11 @@ def attach_ctrl_c_handler(stop_file):
 
     signal.signal(signal.SIGINT, graceful_stop_callback)
 
+def runner_update(item):
+    global runner
+    open("UPDATE", "a").close
+    item.log_output("Pipeline will automatically update after stopping.")
+    runner.stop_gracefully()
 
 if __name__ == "__main__":
     main()

--- a/seesaw/script/run_warrior.py
+++ b/seesaw/script/run_warrior.py
@@ -44,6 +44,8 @@ def setup_logging(log_dir):
 
 
 def main():
+    global warrior
+    
     parser = ArgumentParser(description="Run the warrior web interface")
     parser.add_argument("--projects-dir", dest="projects_dir",
                         metavar="DIRECTORY", type=str,
@@ -114,6 +116,11 @@ def main():
 
     warrior.start()
 
+def warrior_update(item):
+    global warrior
+    item.log_output("Warrior will stop and reboot for updates.")
+    warrior.reboot_gracefully()
+    warrior.schedule_forced_reboot()
 
 if __name__ == "__main__":
     main()

--- a/seesaw/tracker.py
+++ b/seesaw/tracker.py
@@ -68,9 +68,11 @@ class TrackerRequest(Task):
                 r = ("Tracker rate limiting is active. "
                      "We don't want to overload the site we're archiving, "
                      "so we've limited the number of downloads per minute. ")
+                update = 0
             elif response.code == 404:
                 r = ("No item received. There aren't any items available "
                      "for this project at the moment. Try again later. ")
+                update = 0
             elif response.code == 455:
                 r = ("Project code is out of date and needs to be upgraded. "
                      "To remedy this problem immediately, you may reboot "
@@ -79,6 +81,7 @@ class TrackerRequest(Task):
             elif response.code == 599:
                 r = ("No HTTP response received from tracker. "
                      "The tracker is probably overloaded. ")
+                update = 0
             else:
                 r = ("Tracker returned status code %d. "
                      "The tracker has probably malfunctioned. "

--- a/seesaw/tracker.py
+++ b/seesaw/tracker.py
@@ -16,6 +16,7 @@ import seesaw
 from seesaw.config import realize
 from seesaw.task import Task, SimpleTask
 from seesaw.externalprocess import RsyncUpload, CurlUpload
+from seesaw.util import check_update
 
 
 class TrackerRequest(Task):
@@ -74,6 +75,7 @@ class TrackerRequest(Task):
                 r = ("Project code is out of date and needs to be upgraded. "
                      "To remedy this problem immediately, you may reboot "
                      "your warrior. ")
+                update = 1
             elif response.code == 599:
                 r = ("No HTTP response received from tracker. "
                      "The tracker is probably overloaded. ")
@@ -83,6 +85,8 @@ class TrackerRequest(Task):
                      ) % (response.code)
             self.schedule_retry(item, r)
             self.increment_retry_delay()
+            if update == 1:
+                check_update(item)
 
     def schedule_retry(self, item, message=""):
         if self._set_may_be_canceled:

--- a/seesaw/util.py
+++ b/seesaw/util.py
@@ -59,3 +59,11 @@ def unique_id_str():
     '''Returns a unique string suitable for IDs.'''
     rand_str = base64.b16encode(os.urandom(8)).decode('ascii').lower()
     return "{0}{1}".format(int(time.time()), rand_str)
+
+def check_update(item):
+    if seesaw.runner_type == "Standalone" and os.getenv("WRAPPED_RUNNER") == "1":
+        seesaw.script.run_pipeline.runner_update(item)
+    elif seesaw.runner_type == "Warrior" and not os.getenv("DOCKER") == "1":
+        seesaw.script.run_warrior.warrior_update(item)
+    else:
+        pass


### PR DESCRIPTION
This pull request adds the ability to trigger automatic updates for runners and warriors using the preexisting out-of-date signal in the tracker.  Note that runners have to use the shell script and warriors cannot be updated if they use docker.