### PR TITLE
tracker.py: Decode response body when applicable

### DIFF
--- a/seesaw/tracker.py
+++ b/seesaw/tracker.py
@@ -16,6 +16,7 @@ import seesaw
 from seesaw.config import realize
 from seesaw.task import Task, SimpleTask
 from seesaw.externalprocess import RsyncUpload, CurlUpload
+import seesaw.six
 
 
 class TrackerRequest(Task):
@@ -61,7 +62,10 @@ class TrackerRequest(Task):
     def handle_response(self, item, response):
         if response.code == 200:
             self.reset_retry_delay()
-            self.process_body(response.body, item)
+            if isinstance(response.body, seesaw.six.binary_type):
+                self.process_body(response.body.decode('utf-8'), item)
+            else:
+                self.process_body(response.body, item)
         else:
             if response.code == 420 or response.code == 429:
                 r = ("Tracker rate limiting is active. "


### PR DESCRIPTION
When running under Python 3, response.body is a `bytes` object, but
process_body assumes it is passed a string.

This commit addresses that, fixing the following error:

Starting GetItemFromTracker for Item
Failed GetItemFromTracker for Item
Traceback (most recent call last):
  File "[...]/lib/python3.4/site-packages/tornado/stack_context.py", line 314, in wrapped
    ret = fn(*args, **kwargs)
  File "[...]/lib/python3.4/site-packages/seesaw/tracker.py", line 64, in handle_response
    self.process_body(response.body, item)
  File "[...]/lib/python3.4/site-packages/seesaw/tracker.py", line 125, in process_body
    data = json.loads(body)
  File "/usr/lib64/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'