### PR TITLE
Fixed a redundant scrollbar on web page

### DIFF
--- a/seesaw/public/style.css
+++ b/seesaw/public/style.css
@@ -299,7 +299,7 @@ table.time-left td span {
   margin: 0 3px 0 5px;
   padding-right: 2px;
   width: 200px;
-  max-height: 206px;
+  max-height: 208px;
   overflow-y: auto;
 }
 .item.closed ol.tasks {


### PR DESCRIPTION
The max-height is 1px short, the whole bar on the left is 207px tall.
Changing the max-height to 208px should be sufficient; but disabling this parameter completely would do it too.

![2016 03 18_21-59-03__scrollbar-warrior-webpage](https://cloud.githubusercontent.com/assets/1168140/13892279/98a73d8e-ed56-11e5-819e-cbacd9d14573.png)
