### PR TITLE
Fix performance issue with large item logs

### DIFF
--- a/seesaw/public/script.js
+++ b/seesaw/public/script.js
@@ -132,7 +132,7 @@ $(function() {
     var itemLog = $('#item-' + msg.item_id + ' pre.log')[0];
     if (itemLog) {
       if (itemLog.data) {
-        itemLog.data = processCarriageReturns(itemLog.data + msg.data);
+        itemLog.data += processCarriageReturns(msg.data);
         itemLog.data = itemLog.data.split('\n').slice(-500).join('\n')
         itemLog.firstChild.nodeValue = itemLog.data;
       } else {


### PR DESCRIPTION
Over time as an item log grows, the time spent running processCarriageReturns grows
until it takes longer to run than it takes for the next message to arrive, locking up the
tab

I don't know exactly what problem this function solves, but without this change the
web interface is unusable