### PR TITLE
Show days elapsed for long running Warrior jobs.

### DIFF
--- a/seesaw/public/script.js
+++ b/seesaw/public/script.js
@@ -261,10 +261,11 @@ $(function() {
        
        // Generate friendly time display
        // http://stackoverflow.com/questions/1322732/convert-seconds-to-hh-mm-ss-with-javascript
+       var days = parseInt( timeDiff / 86400 ) % 31;
        var hours = parseInt( timeDiff / 3600 ) % 24;
        var minutes = parseInt( timeDiff / 60 ) % 60;
        var seconds = timeDiff % 60;
-       var result = (hours < 10 ? "0" + hours : hours) + "h " + (minutes < 10 ? "0" + minutes : minutes) + "m " + (seconds  < 10 ? "0" + seconds : seconds) + "s ";
+       var result = (days < 10 ? "0" + days : days) + "d " + (hours < 10 ? "0" + hours : hours) + "h " + (minutes < 10 ? "0" + minutes : minutes) + "m " + (seconds  < 10 ? "0" + seconds : seconds) + "s ";
        
        //Save the calculated duration back to the DOM
        $(".item-duration-counter", obj).text('Elapsed: ' + result);


### PR DESCRIPTION
With Tumblr, jobs sometimes can run for more than a day and the elapsed time rolls back to 0 hours. This fixes that by adding days to the elapsed time JS.

~~God forbid that a job takes more than 31 days to run~~