### PR TITLE
Remove rsync compression

### DIFF
--- a/seesaw/externalprocess.py
+++ b/seesaw/externalprocess.py
@@ -285,7 +285,7 @@ class RsyncUpload(ExternalProcess):
                  max_tries=None, extra_args=None):
         args = [
             "rsync",
-            "-rltvz",
+            "-rltv",
             "--timeout=300",
             "--contimeout=300",
             "--progress",

--- a/seesaw/externalprocess.py
+++ b/seesaw/externalprocess.py
@@ -286,7 +286,6 @@ class RsyncUpload(ExternalProcess):
         args = [
             "rsync",
             "-rltvz",
-            "--compress-level=9",
             "--timeout=300",
             "--contimeout=300",
             "--progress",


### PR DESCRIPTION
Fairly unnecessary these days as we're usually not bandwidth-limited, and provides a small performance bonus.
