### PR TITLE
Keep collapsed item view to single lines only.

### DIFF
--- a/seesaw/public/style.css
+++ b/seesaw/public/style.css
@@ -238,6 +238,8 @@ table.time-left td span {
 }
 .item.closed {
   padding-bottom: 0;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .item h3 {
   margin: 0 0 5px 0;


### PR DESCRIPTION
This stops that annoying jumping around it does on long lines.