### PR TITLE
Fix spurious RsyncUpload failures

### DIFF
--- a/seesaw/tracker.py
+++ b/seesaw/tracker.py
@@ -256,7 +256,7 @@ class UploadWithTracker(TrackerRequest):
 
             inner_task.on_complete_item += self._inner_task_complete_item
             inner_task.on_fail_item += self._inner_task_fail_item
-            inner_task.enqueue(item)
+            self._enqueue_inner_task_with_except(inner_task, item)
 
         else:
             item.log_output("Tracker did not provide an upload target.")


### PR DESCRIPTION
This fixes issue #48 where an RsyncUpload task will appear to randomly fail leaving an empty directory and causing all retries to fail. The first commit (24c1bf3) is the main fix, ignoring spurious EINTR errors during I/O, with the other two commits attempting to improve the general robustness of error handling surrounding external process tasks.