### PR TITLE
Fixed twisties and made completed items green

### DIFF
--- a/seesaw/public/script.js
+++ b/seesaw/public/script.js
@@ -657,16 +657,14 @@ $(function() {
 
   showTab('view-current-project');
 
-  $(".item.closed .twisty").delegate('click',
-                                 function () {
-                                   $(this).parent().parent().removeClass('closed')
-                                                            .addClass('open');
-                                 });
-  $(".item.open .twisty").delegate('click',
-                               function () {
-                                 $(this).parent().parent().removeClass('open')
-                                                          .addClass('closed');
-                               });
+  $(document).on("click", ".item.closed .twisty", function () {
+    $(this).parent().parent().removeClass('closed')
+      .addClass('open')
+  });
+  $(document).on("click", ".item.open .twisty", function () {
+    $(this).parent().parent().removeClass('open')
+      .addClass('closed')
+  });
 
   /*
   addItem({

--- a/seesaw/public/style.css
+++ b/seesaw/public/style.css
@@ -254,6 +254,12 @@ table.time-left td span {
 .item-failed h3 strong {
   background: #A70B0B;
 }
+.item-completed h3 {
+  background: #326827;
+}
+.item-completed h3 strong {
+  background: #326827;
+}
 .item.open .status-line {
   display: none;
 }
@@ -268,8 +274,9 @@ table.time-left td span {
   display: inline-block;
   width: 1em;
   padding-right: 3px;
-  background: #190A06;
+  background: inherit;
   border-radius: 3px;
+  cursor: pointer;
 }
 .item.open .twisty:before {
   content: "▼";


### PR DESCRIPTION
* Made twisties use `.on()` instead of `.delegate()` per jQuery docs: 
> As of jQuery 3.0, .delegate() has been deprecated. **It was superseded by the `.on()` method since jQuery 1.7**, so its use was already discouraged.

The twisties weren't clickable for me using `.delegate()`, but they are with `.on()`.

* Made twisties use `background-color: inherit;` to remove the black circle behind twisties if the task is failed/completed, and `cursor: pointer;` to indicate the twisties are clickable.

* Made completed items green, like how failed items are red.