### PR TITLE
Improve webserver mount-point compatibility (#129)

### DIFF
--- a/seesaw/public/index-dummy.html
+++ b/seesaw/public/index-dummy.html
@@ -39,7 +39,7 @@
         </tr>
         <tr>
           <td>
-            <form method="post" action="/api/stop" class="js-api-form">
+            <form method="post" action="api/stop" class="js-api-form">
               <input type="submit" value="Stop" />
             </form>
           </td>
@@ -227,7 +227,7 @@
         <li>
           <h4>ArchiveTeam&#8217;s Choice</h4>
           <p>Your warrior will automatically work on the most urgent project.</p>
-          <form method="post" action="/api/stop" class="js-api-form">
+          <form method="post" action="api/stop" class="js-api-form">
             <div class="select"><input type="submit" value="Stop this project" /></div>
           </form>
         </li>
@@ -238,7 +238,7 @@
         <li class="with-time-left">
           <h4>Example project</h4>
           <p>An example</p>
-          <form method="post" action="/api/stop" class="js-api-form">
+          <form method="post" action="api/stop" class="js-api-form">
             <div class="select"><input type="submit" value="Work on this project" /></div>
           </form>
           <table class="time-left" cellspacing="0">
@@ -257,7 +257,7 @@
           <img class="project-logo" alt="Picplz" src="https://s3.amazonaws.com/data.tumblr.com/tumblr_l3vf57DJ1e1qaewyu.png" height="50px" />
           <h4>Picplz</h4>
           <p>An example</p>
-          <form method="post" action="/api/stop" class="js-api-form">
+          <form method="post" action="api/stop" class="js-api-form">
             <div class="select"><input type="submit" value="Work on this project" /></div>
           </form>
         </li>
@@ -265,7 +265,7 @@
           <img class="project-logo" alt="Picplz" src="https://s3.amazonaws.com/data.tumblr.com/tumblr_l3vf57DJ1e1qaewyu.png" height="50px" />
           <h4>Picplz</h4>
           <p>An example</p>
-          <form method="post" action="/api/stop" class="js-api-form">
+          <form method="post" action="api/stop" class="js-api-form">
             <div class="select"><span class="installing">Preparing project...</span></div>
           </form>
         </li>
@@ -273,7 +273,7 @@
           <img class="project-logo" alt="Picplz" src="https://s3.amazonaws.com/data.tumblr.com/tumblr_l3vf57DJ1e1qaewyu.png" height="50px" />
           <h4>Picplz</h4>
           <p>An example</p>
-          <form method="post" action="/api/stop" class="js-api-form">
+          <form method="post" action="api/stop" class="js-api-form">
             <div class="select"><input type="submit" value="Work on this project" /></div>
           </form>
           <div class="installation-failed">
@@ -297,7 +297,7 @@
     </div>
     <div id="settings">
 
-      <form method="post" action="/api/stop" class="js-api-form">
+      <form method="post" action="api/stop" class="js-api-form">
         <ul id="settings-list">
           <li>
             <p><label for="f-settings-downloader">Your nickname</label></p>

--- a/seesaw/public/index.html
+++ b/seesaw/public/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
@@ -47,14 +47,14 @@
         </tr>
         <tr>
           <td>
-            <form id="warrior-status-form" method="post" action="/api/stop" class="js-api-form">
+            <form id="warrior-status-form" method="post" action="api/stop" class="js-api-form">
               <input type="submit" value="Stop" />
             </form>
           </td>
         </tr>
         <tr>
           <td>
-            <form id="warrior-status-form-force" method="post" action="/api/stop_now" class="js-api-form" style="display: none">
+            <form id="warrior-status-form-force" method="post" action="api/stop_now" class="js-api-form" style="display: none">
               <input type="submit" value="Stop immediately" />
             </form>
           </td>
@@ -102,7 +102,7 @@
       <p>Customize your warrior</p>
     </div>
     <div id="settings">
-      <form method="post" action="/api/settings" id="settings-form">
+      <form method="post" action="api/settings" id="settings-form">
         <p class="advanced-settings-field"><label for="f-advanced-settings"><input type="checkbox" name="advanced_settings" value="1" id="f-advanced-settings">Show advanced settings</label></p>
         <ul id="settings-list"></ul>
         <ul>

--- a/seesaw/public/script.js
+++ b/seesaw/public/script.js
@@ -1,5 +1,5 @@
 $(function() {
-  var conn = new SockJS(window.location.protocol + '//' + window.location.host);
+  var conn = new SockJS(window.location.protocol + '//' + window.location.host + window.location.pathname);
   var multiProject = false;
   var instanceID = null;
   var eventCallbacks = {};
@@ -273,18 +273,18 @@ $(function() {
   });
 
   function reloadProjectsTab() {
-    $('#projects').load('/api/all-projects', null, function() {
+    $('#projects').load('api/all-projects', null, function() {
       $("#projects input[type='submit']").each(makeButtonLink);
       $("#projects li").each(addProjectCountdown);
     });
   }
 
   function reloadSettingsTab() {
-    $('#settings-list').load('/api/settings');
+    $('#settings-list').load('api/settings');
   }
 
   function reloadHelpTab() {
-    $('#help').load('/api/help');
+    $('#help').load('api/help');
     $('#broadcastMessage-indicator').hide();
     
     if (localStorage) {
@@ -293,17 +293,17 @@ $(function() {
   }
 
   var warriorStatus = {
-    'UNINITIALIZED': ['The warrior could not contact HQ. Please reboot.', 'Shut down', '/api/stop'],
-    'NO_PROJECT': ['The warrior is idle. Select a project.', 'Shut down', '/api/stop'],
-    'INVALID_SETTINGS': ['You must configure the warrior.', 'Shut down', '/api/stop'],
-    'STOPPING_PROJECT': ['The warrior is stopping the current project.', 'Shut down', '/api/stop'],
-    'RESTARTING_PROJECT': ['The warrior is restarting the current project.', 'Shut down', '/api/stop'],
-    'RUNNING_PROJECT': ['The warrior is working on a project.', 'Shut down', '/api/stop'],
-    'SWITCHING_PROJECT': ['The warrior will switch to a different project.', 'Shut down', '/api/stop'],
-    'STARTING_PROJECT': ['The warrior is beginning work on a project.', 'Shut down', '/api/stop'],
-    'SHUTTING_DOWN': ['The warrior is stopping and shutting down.', 'Keep running', '/api/keep_running',
-                      'Stop immediately', '/api/stop_now'],
-    'REBOOTING': ['The warrior is stopping and restarting.', 'Keep running', '/api/keep_running']
+    'UNINITIALIZED': ['The warrior could not contact HQ. Please reboot.', 'Shut down', 'api/stop'],
+    'NO_PROJECT': ['The warrior is idle. Select a project.', 'Shut down', 'api/stop'],
+    'INVALID_SETTINGS': ['You must configure the warrior.', 'Shut down', 'api/stop'],
+    'STOPPING_PROJECT': ['The warrior is stopping the current project.', 'Shut down', 'api/stop'],
+    'RESTARTING_PROJECT': ['The warrior is restarting the current project.', 'Shut down', 'api/stop'],
+    'RUNNING_PROJECT': ['The warrior is working on a project.', 'Shut down', 'api/stop'],
+    'SWITCHING_PROJECT': ['The warrior will switch to a different project.', 'Shut down', 'api/stop'],
+    'STARTING_PROJECT': ['The warrior is beginning work on a project.', 'Shut down', 'api/stop'],
+    'SHUTTING_DOWN': ['The warrior is stopping and shutting down.', 'Keep running', 'api/keep_running',
+                      'Stop immediately', 'api/stop_now'],
+    'REBOOTING': ['The warrior is stopping and restarting.', 'Keep running', 'api/keep_running']
   };
 
   function showWarriorStatus(status) {
@@ -323,9 +323,9 @@ $(function() {
   }
 
   var runnerStatus = {
-    'running':  ['The runner is running.', 'Stop', '/api/stop'],
-    'stopping': ['The runner is stopping.', 'Keep running', '/api/keep_running',
-                 'Stop immediately', '/api/stop_now']
+    'running':  ['The runner is running.', 'Stop', 'api/stop'],
+    'stopping': ['The runner is stopping.', 'Keep running', 'api/keep_running',
+                 'Stop immediately', 'api/stop_now']
   };
 
   function showRunnerStatus(status) {

--- a/seesaw/templates/all-projects.html
+++ b/seesaw/templates/all-projects.html
@@ -7,7 +7,7 @@
       <li>
         <h4>ArchiveTeam&#8217;s Choice</h4>
         <p>Your warrior will automatically work on the current ArchiveTeam project.</p>
-        <form method="post" action="/api/deselect-project" class="js-api-form">
+        <form method="post" action="api/deselect-project" class="js-api-form">
           <div class="select"><input type="hidden" name="project_name" value="{{ project_name }}" /><input type="submit" value="Stop this project" /></div>
         </form>
       </li>
@@ -23,7 +23,7 @@
         {% end %}
         <h4>{{ project_data["title"] }}</h4>
         <p>{{ project_data["description"] }}</p>
-        <form method="post" action="/api/deselect-project" class="js-api-form">
+        <form method="post" action="api/deselect-project" class="js-api-form">
           <div class="select"><input type="hidden" name="project_name" value="{{ project_name }}" /><input type="submit" value="Stop this project" /></div>
         </form>
       </li>
@@ -37,7 +37,7 @@
     <li>
       <h4>ArchiveTeam&#8217;s Choice</h4>
       <p>Your warrior will automatically work on the current ArchiveTeam project.</p>
-      <form method="post" action="/api/select-project" class="js-api-form">
+      <form method="post" action="api/select-project" class="js-api-form">
         <div class="select"><input type="hidden" name="project_name" value="auto" /><input type="submit" value="Work on this project" /></div>
       </form>
     </li>
@@ -50,7 +50,7 @@
         {% end %}
         <h4>{{ project_data["title"] }}</h4>
         <p>{{ project_data["description"] }}</p>
-        <form method="post" action="/api/select-project" class="js-api-form">
+        <form method="post" action="api/select-project" class="js-api-form">
           <div class="select"><input type="hidden" name="project_name" value="{{ project_name }}" /><input type="submit" value="Work on this project" /></div>
         </form>
       </li>


### PR DESCRIPTION
As proposed in my issue ArchiveTeam/seesaw-kit#129, the client-side interactive stuff should behave similar to the assets loaded by the website (js, css, ...). Let SockJS and the browser handle the details.

In a setup where the webinterface is running behind a reverse proxy at a different path, requests done
by the JavaScript go to the wrong path.
(Reverse proxy is setup in a way where the
browser/webserver sees `/warrior1/api/stop` but seesaw-kit still sees `/api/stop`.

---

With a little hack these changes are currently used for my running setup, successfully *hosting* multiple warriors behind the same host but on different paths.