### PR TITLE
Update style.css so the long item name won't overflow (issue 156)

### DIFF
--- a/seesaw/public/style.css
+++ b/seesaw/public/style.css
@@ -277,6 +277,10 @@ table.time-left td span {
 .item.closed .twisty:before {
   content: "▶";
 }
+.item .name {
+  white-space: normal;
+  overflow-wrap: break-word;
+}
 .item div.number {
   padding: 5px 7px 0 10px;
   position: absolute;


### PR DESCRIPTION
Implementation of issue https://github.com/ArchiveTeam/seesaw-kit/issues/156 which should fix the overflow