### PR TITLE
Add global up/down bandwidth limits to the warrior

### DIFF
--- a/seesaw/bandwidth.py
+++ b/seesaw/bandwidth.py
@@ -1,0 +1,98 @@
+'''Global bandwidth-limit registry.
+
+Holds the operator-configured aggregate download/upload caps (KiB/s) and the
+live concurrency divisors, and computes the per-process limit each spawned
+wget/rsync/curl worker should receive. Populated by the warrior (or the
+standalone runner); read by the external-process tasks when they realize their
+argument lists.
+
+When a total is unset or ``0`` every accessor returns ``None`` so process
+arguments are left unchanged -- this keeps plain ``run-pipeline`` behaviour
+identical for anyone who does not set a limit.
+
+A cap is an aggregate *ceiling*: ``per_process = max(1, total // divisor)``.
+It is conservative (it under-shoots when fewer than ``divisor`` workers are
+actually transferring) and never exceeds the configured total.
+'''
+
+# Module-global registry. Same idiom as ``_all_procs`` in externalprocess and
+# ``ConfigValue.collector`` in config.
+_limits = {
+    "download": None,
+    "upload": None,
+    "download_divisor": None,
+    "upload_divisor": None,
+}
+
+
+def set_limits(download=None, upload=None,
+               download_divisor=None, upload_divisor=None):
+    '''Populate the registry. Each value may be a plain int, a callable
+    returning an int, or any object with a ``realize(item)`` method (e.g. a
+    ``ConfigValue``), so live UI/config changes are tracked.'''
+    _limits["download"] = download
+    _limits["upload"] = upload
+    _limits["download_divisor"] = download_divisor
+    _limits["upload_divisor"] = upload_divisor
+
+
+def reset():
+    '''Clear the registry (no limits). Used by the test suite and any caller
+    that wants to disable limiting.'''
+    set_limits()
+
+
+def _resolve(value, item):
+    if value is None:
+        return None
+    if hasattr(value, "realize"):
+        return value.realize(item)
+    if callable(value):
+        return value()
+    return value
+
+
+def _per_process(total_key, divisor_key, item):
+    total = _resolve(_limits[total_key], item)
+    if total is None:
+        return None
+    total = int(total)
+    if total <= 0:
+        return None
+    divisor = _resolve(_limits[divisor_key], item)
+    divisor = int(divisor) if divisor is not None else 1
+    if divisor < 1:
+        divisor = 1
+    return max(1, total // divisor)
+
+
+def download_kib(item=None):
+    return _per_process("download", "download_divisor", item)
+
+
+def upload_kib(item=None):
+    return _per_process("upload", "upload_divisor", item)
+
+
+def wget_limit_rate(item=None):
+    '''wget ``--limit-rate`` value: per-process KiB with a ``k`` suffix
+    (wget's ``k`` == 1024 bytes), or ``None`` for unlimited.'''
+    kib = download_kib(item)
+    return "%dk" % kib if kib is not None else None
+
+
+def rsync_bwlimit(item=None):
+    '''rsync ``--bwlimit`` value: a bare integer (rsync's native unit is KiB/s),
+    or ``None`` for unlimited. Bare integer keeps compatibility with rsync
+    < 3.1 (no suffix support).'''
+    kib = upload_kib(item)
+    return str(kib) if kib is not None else None
+
+
+def curl_limit_rate(item=None):
+    '''curl ``--limit-rate`` value: per-process KiB with a ``k`` suffix,
+    or ``None`` for unlimited. curl's suffixes are 1024-based (``k`` == ``K``
+    == 1024 bytes), matching wget, so the same KiB value is consistent across
+    both tools.'''
+    kib = upload_kib(item)
+    return "%dk" % kib if kib is not None else None

--- a/seesaw/bandwidth_test.py
+++ b/seesaw/bandwidth_test.py
@@ -1,0 +1,70 @@
+# encoding=utf8
+from __future__ import unicode_literals
+
+import unittest
+
+from seesaw import bandwidth
+
+
+class BandwidthRegistryTest(unittest.TestCase):
+    def tearDown(self):
+        bandwidth.reset()
+
+    def test_unset_returns_none(self):
+        bandwidth.reset()
+        self.assertIsNone(bandwidth.download_kib())
+        self.assertIsNone(bandwidth.upload_kib())
+        self.assertIsNone(bandwidth.wget_limit_rate())
+        self.assertIsNone(bandwidth.rsync_bwlimit())
+        self.assertIsNone(bandwidth.curl_limit_rate())
+
+    def test_zero_total_is_unlimited(self):
+        bandwidth.set_limits(download=0, upload=0,
+                             download_divisor=2, upload_divisor=4)
+        self.assertIsNone(bandwidth.download_kib())
+        self.assertIsNone(bandwidth.upload_kib())
+
+    def test_download_divided_by_concurrency(self):
+        bandwidth.set_limits(download=1000, download_divisor=4)
+        self.assertEqual(250, bandwidth.download_kib())
+        self.assertEqual("250k", bandwidth.wget_limit_rate())
+
+    def test_upload_divided_and_formatted(self):
+        bandwidth.set_limits(upload=1000, upload_divisor=4)
+        self.assertEqual(250, bandwidth.upload_kib())
+        self.assertEqual("250", bandwidth.rsync_bwlimit())
+        self.assertEqual("250k", bandwidth.curl_limit_rate())
+
+    def test_floor_is_one(self):
+        bandwidth.set_limits(download=3, download_divisor=10)
+        self.assertEqual(1, bandwidth.download_kib())
+
+    def test_string_typed_total_and_divisor(self):
+        # Config sources may hand back numeric strings; they must coerce.
+        bandwidth.set_limits(download="1000", download_divisor="2")
+        self.assertEqual(500, bandwidth.download_kib())
+        self.assertEqual("500k", bandwidth.wget_limit_rate())
+
+    def test_divisor_below_one_is_clamped(self):
+        bandwidth.set_limits(download=1000, download_divisor=lambda: 0)
+        self.assertEqual(1000, bandwidth.download_kib())
+
+    def test_divisor_callable_resolved_live(self):
+        state = {"n": 2}
+        bandwidth.set_limits(download=1000,
+                             download_divisor=lambda: state["n"])
+        self.assertEqual(500, bandwidth.download_kib())
+        state["n"] = 5
+        self.assertEqual(200, bandwidth.download_kib())
+
+    def test_total_realizable_object(self):
+        class Live(object):
+            value = 800
+
+            def realize(self, item):
+                return self.value
+        live = Live()
+        bandwidth.set_limits(download=live, download_divisor=2)
+        self.assertEqual(400, bandwidth.download_kib())
+        live.value = 200
+        self.assertEqual(100, bandwidth.download_kib())

--- a/seesaw/externalprocess.py
+++ b/seesaw/externalprocess.py
@@ -18,6 +18,7 @@ import tornado.process
 from seesaw.event import Event
 from seesaw.task import Task
 from seesaw.config import realize
+from seesaw import bandwidth
 import time
 
 
@@ -192,10 +193,17 @@ class ExternalProcess(Task):
     def stdin_data(self, item):
         return b""
 
+    def realize_args(self, item):
+        '''Realize the argument list for this run. Subclasses override this to
+        inject global options (e.g. bandwidth limits) on top of the
+        pipeline-supplied args. Default behaviour is identical to realizing
+        ``self.args`` directly.'''
+        return realize(self.args, item)
+
     def process(self, item):
         with self.task_cwd():
             p = AsyncPopen2(
-                args=realize(self.args, item),
+                args=self.realize_args(item),
                 env=realize(self.env, item),
                 stdin=subprocess.PIPE,
                 close_fds=True
@@ -287,6 +295,14 @@ class WgetDownload(ExternalProcess):
         else:
             return b""
 
+    def realize_args(self, item):
+        args = ExternalProcess.realize_args(self, item)
+        limit_rate = bandwidth.wget_limit_rate(item)
+        if limit_rate is not None and not any(
+                str(a).startswith("--limit-rate") for a in args):
+            args = list(args) + ["--limit-rate=%s" % limit_rate]
+        return args
+
 
 class RsyncUpload(ExternalProcess):
     '''Upload with Rsync process runner.'''
@@ -312,6 +328,31 @@ class RsyncUpload(ExternalProcess):
                                  max_tries=max_tries)
         self.files = files
         self.target_source_path = target_source_path
+
+    def realize_args(self, item):
+        args = list(ExternalProcess.realize_args(self, item))
+        bwlimit = bandwidth.rsync_bwlimit(item)
+        if bwlimit is not None:
+            # Strip any caller-supplied --bwlimit (both the "--bwlimit N" and
+            # "--bwlimit=N" forms), then apply the operator's global cap as a
+            # single authoritative value just after argv[0]. This keeps the
+            # cap deterministic regardless of how the rsync args were built
+            # (RsyncUpload's own default "--bwlimit 0", extra_args, etc.).
+            cleaned = []
+            skip_next = False
+            for arg in args:
+                if skip_next:
+                    skip_next = False
+                    continue
+                text = str(arg)
+                if text == "--bwlimit":
+                    skip_next = True
+                    continue
+                if text.startswith("--bwlimit="):
+                    continue
+                cleaned.append(arg)
+            args = cleaned[:1] + ["--bwlimit", bwlimit] + cleaned[1:]
+        return args
 
     def stdin_data(self, item):
         return "".join(
@@ -346,3 +387,11 @@ class CurlUpload(ExternalProcess):
         ExternalProcess.__init__(self, "CurlUpload",
                                  args=args,
                                  max_tries=max_tries)
+
+    def realize_args(self, item):
+        args = list(ExternalProcess.realize_args(self, item))
+        limit_rate = bandwidth.curl_limit_rate(item)
+        if limit_rate is not None and not any(
+                str(a).startswith("--limit-rate") for a in args):
+            args += ["--limit-rate", limit_rate]
+        return args

--- a/seesaw/externalprocess_test.py
+++ b/seesaw/externalprocess_test.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 
 from seesaw.externalprocess import ExternalProcess
+from seesaw.externalprocess import WgetDownload, RsyncUpload, CurlUpload
+from seesaw import bandwidth
 from seesaw.pipeline import Pipeline
 from seesaw.runner import SimpleRunner
 from seesaw.six import StringIO
@@ -122,3 +124,112 @@ class ExternalProcessTest(BaseTestCase):
 
         self.assertFalse(pipeline.has_failed)
         self.assertIOLoopOK()
+
+
+class RealizeArgsDefaultTest(BaseTestCase):
+    def tearDown(self):
+        bandwidth.reset()
+        BaseTestCase.tearDown(self)
+
+    def test_default_realize_args_unchanged(self):
+        bandwidth.reset()
+        proc = ExternalProcess("Echo", ["echo", "hi"])
+        self.assertEqual(["echo", "hi"], proc.realize_args(None))
+
+
+class WgetLimitRateTest(BaseTestCase):
+    def tearDown(self):
+        bandwidth.reset()
+        BaseTestCase.tearDown(self)
+
+    def test_no_limit_by_default(self):
+        bandwidth.reset()
+        task = WgetDownload(["wget", "http://example.com/"])
+        args = task.realize_args(None)
+        self.assertFalse(any(str(a).startswith("--limit-rate") for a in args))
+
+    def test_limit_injected(self):
+        bandwidth.set_limits(download=1000, download_divisor=2)
+        task = WgetDownload(["wget", "http://example.com/"])
+        args = task.realize_args(None)
+        self.assertIn("--limit-rate=500k", args)
+
+    def test_pipeline_supplied_limit_not_doubled(self):
+        bandwidth.set_limits(download=1000, download_divisor=2)
+        task = WgetDownload(["wget", "--limit-rate=10k", "http://example.com/"])
+        args = task.realize_args(None)
+        self.assertEqual(
+            1, len([a for a in args if str(a).startswith("--limit-rate")]))
+        self.assertIn("--limit-rate=10k", args)
+
+
+class RsyncBwlimitTest(BaseTestCase):
+    def tearDown(self):
+        bandwidth.reset()
+        BaseTestCase.tearDown(self)
+
+    def test_default_bwlimit_preserved(self):
+        bandwidth.reset()
+        task = RsyncUpload("user@host::module/", ["afile"])
+        args = task.realize_args(None)
+        idx = args.index("--bwlimit")
+        self.assertEqual("0", args[idx + 1])
+
+    def test_bwlimit_overridden(self):
+        bandwidth.set_limits(upload=1000, upload_divisor=4)
+        task = RsyncUpload("user@host::module/", ["afile"])
+        args = task.realize_args(None)
+        idx = args.index("--bwlimit")
+        self.assertEqual("250", args[idx + 1])
+
+    def test_bwlimit_injected_when_absent(self):
+        bandwidth.set_limits(upload=1000, upload_divisor=4)
+        task = RsyncUpload("user@host::module/", ["afile"])
+        # Simulate an rsync arg list with no --bwlimit slot (e.g. a custom
+        # pipeline command): the global cap must still be applied.
+        task.args = ["rsync", "-rltv", "src/", "user@host::module/"]
+        args = task.realize_args(None)
+        idx = args.index("--bwlimit")
+        self.assertEqual("250", args[idx + 1])
+        self.assertEqual(1, args.count("--bwlimit"))
+
+    def test_bwlimit_equals_form_normalized(self):
+        bandwidth.set_limits(upload=1000, upload_divisor=4)
+        task = RsyncUpload("user@host::module/", ["afile"])
+        # A caller-supplied "--bwlimit=N" (equals form) must be normalized to a
+        # single authoritative cap, not left as a duplicate.
+        task.args = ["rsync", "--bwlimit=50", "src/", "user@host::module/"]
+        args = task.realize_args(None)
+        self.assertEqual(1, args.count("--bwlimit"))
+        self.assertFalse(any(str(a).startswith("--bwlimit=") for a in args))
+        self.assertEqual("250", args[args.index("--bwlimit") + 1])
+
+
+class CurlLimitRateTest(BaseTestCase):
+    def tearDown(self):
+        bandwidth.reset()
+        BaseTestCase.tearDown(self)
+
+    def test_no_limit_by_default(self):
+        bandwidth.reset()
+        task = CurlUpload("http://host/", "afile")
+        args = task.realize_args(None)
+        self.assertNotIn("--limit-rate", args)
+
+    def test_pipeline_supplied_limit_not_doubled(self):
+        bandwidth.set_limits(upload=1000, upload_divisor=2)
+        task = CurlUpload("http://host/", "afile")
+        # An existing --limit-rate (equals form) must not be doubled.
+        task.args = ["curl", "--limit-rate=10k", "--upload-file", "afile",
+                     "http://host/"]
+        args = task.realize_args(None)
+        self.assertEqual(
+            1, len([a for a in args if str(a).startswith("--limit-rate")]))
+        self.assertIn("--limit-rate=10k", args)
+
+    def test_limit_injected(self):
+        bandwidth.set_limits(upload=1000, upload_divisor=2)
+        task = CurlUpload("http://host/", "afile")
+        args = task.realize_args(None)
+        self.assertIn("--limit-rate", args)
+        self.assertEqual("500k", args[args.index("--limit-rate") + 1])

--- a/seesaw/script/run_pipeline.py
+++ b/seesaw/script/run_pipeline.py
@@ -11,6 +11,7 @@ import time
 from seesaw.runner import SimpleRunner
 from seesaw.web import start_runner_server
 import seesaw
+from seesaw import bandwidth
 import tornado.ioloop
 import signal
 
@@ -199,6 +200,17 @@ def main():
     parser.add_argument("--http-password", dest="http_password",
                         help="password for the web interface",
                         metavar="PASSWORD", type=str)
+    parser.add_argument("--download-bwlimit", dest="download_bwlimit",
+                        help="per-transfer download speed cap (KiB/s) applied "
+                             "to each download process; 0 = unlimited. (The "
+                             "warrior applies an aggregate cap shared across "
+                             "concurrent items.)",
+                        metavar="KIB", type=int, default=0)
+    parser.add_argument("--upload-bwlimit", dest="upload_bwlimit",
+                        help="per-transfer upload speed cap (KiB/s) applied to "
+                             "each upload process; 0 = unlimited. (The warrior "
+                             "applies an aggregate cap shared across transfers.)",
+                        metavar="KIB", type=int, default=0)
     parser.add_argument("--context-value", dest="context_values",
                         help="additional pipeline global variables "
                              "(name=text)",
@@ -212,6 +224,18 @@ def main():
 
     check_downloader_or_exit(args.downloader)
     check_concurrency_or_exit(args.concurrent_items)
+    # The standalone runner cannot know a pipeline's actual rsync/wget
+    # concurrency (it is set by each pipeline's own LimitConcurrent wrappers),
+    # so it cannot compute a true aggregate ceiling. Apply the limits
+    # per-transfer (divisor 1) instead, which is honest and never silently
+    # exceeds a per-process cap. The warrior, which owns the concurrency
+    # config, applies these as aggregate caps.
+    bandwidth.set_limits(
+        download=args.download_bwlimit,
+        upload=args.upload_bwlimit,
+        download_divisor=1,
+        upload_divisor=1,
+    )
 
     if args.auto_update:
         check_git_repo_or_exit()

--- a/seesaw/warrior.py
+++ b/seesaw/warrior.py
@@ -23,6 +23,7 @@ from tornado.httpclient import AsyncHTTPClient
 import seesaw
 from seesaw.config import NumberConfigValue, StringConfigValue, ConfigValue
 from seesaw.config import realize
+from seesaw import bandwidth
 from seesaw.event import Event
 from seesaw.externalprocess import AsyncPopen2
 from seesaw.log import InternalTempLogHandler
@@ -213,6 +214,22 @@ class Warrior(object):
             max=6,
             default=2
         )
+        self.download_bwlimit = NumberConfigValue(
+            name="download_bwlimit",
+            title="Download bandwidth limit (KiB/s)",
+            description="Total download speed cap shared across all concurrent "
+                        "items, in KiB/s. 0 = unlimited.",
+            min=0,
+            default=0
+        )
+        self.upload_bwlimit = NumberConfigValue(
+            name="upload_bwlimit",
+            title="Upload bandwidth limit (KiB/s)",
+            description="Total upload speed cap shared across all concurrent "
+                        "rsync/curl transfers, in KiB/s. 0 = unlimited.",
+            min=0,
+            default=0
+        )
         self.http_username = StringConfigValue(
             name="http_username",
             title="HTTP username",
@@ -234,6 +251,29 @@ class Warrior(object):
         self.config_manager.add(self.selected_project_config_value)
         self.config_manager.add(self.downloader)
         self.config_manager.add(self.concurrent_items)
+        self.config_manager.add(self.download_bwlimit)
+        self.config_manager.add(self.upload_bwlimit)
+
+        def _upload_divisor():
+            # Uploads run with up to ``shared:rsync_threads`` concurrent rsync
+            # processes; that config value is registered by the project
+            # pipeline once it loads. Until then, divide by 1 (conservative:
+            # uploads only begin after a project -- and thus rsync_threads --
+            # is loaded).
+            cv = self.config_manager.config_values.get("shared:rsync_threads")
+            if cv is not None:
+                try:
+                    return int(realize(cv, None))
+                except (TypeError, ValueError):
+                    pass
+            return 1
+
+        bandwidth.set_limits(
+            download=self.download_bwlimit,
+            upload=self.upload_bwlimit,
+            download_divisor=self.concurrent_items,
+            upload_divisor=_upload_divisor,
+        )
         self.config_manager.add(self.http_username)
         self.config_manager.add(self.http_password)
 


### PR DESCRIPTION
## Summary

Adds an optional **global up/down bandwidth limit** to the warrior, alongside the existing "Concurrent items" knob. Today the warrior only lets operators bound concurrency; there is no in-app way to cap bandwidth (tracked in #160 and ArchiveTeam/warrior-dockerfile#93). This adds two settings — **Download bandwidth limit** and **Upload bandwidth limit** (KiB/s, `0` = unlimited) — that an operator can set to bound their own egress/ingress.

This is intended as an **operator's own bandwidth cap**, not a way to subvert tracker-side pacing — it simply lets a volunteer say "don't use more than N KiB/s of my connection." For exact, link-level shaping the existing external options (host `tc`/docker-tc, VM bandwidth controls) remain the right tool; this is the lightweight, no-privileges, in-app option.

## How it works

- **`seesaw/bandwidth.py`** — a small process-global registry (same idiom as `_all_procs` / `ConfigValue.collector`) holding the two limit `ConfigValue`s plus the live concurrency divisors. It computes a per-process rate `max(1, total // concurrency)` and formats it per tool. When unset/`0` it returns `None`, so argument lists are untouched (fully backward compatible).
- **`ExternalProcess.realize_args(item)`** — a new hook (default identical to `realize(self.args, item)`). `WgetDownload`/`CurlUpload` append `--limit-rate`; `RsyncUpload` normalizes `--bwlimit`. Because every project pipeline builds on these shared task classes, the cap applies globally with **no per-project `pipeline.py` changes**.
- **Warrior settings** — `download_bwlimit` / `upload_bwlimit` `NumberConfigValue`s that auto-surface in the settings page (`editable_values()`), passed by reference so UI edits take effect live. Downloads divide by `concurrent_items`; uploads by the live `shared:rsync_threads`.
- **Standalone `run-pipeline`** — `--download-bwlimit` / `--upload-bwlimit` flags, applied **per-transfer** (the standalone runner can't know a pipeline's own `LimitConcurrent` values, so it does not claim an aggregate ceiling).

The warrior cap is an **aggregate ceiling**: it is conservative (it under-shoots when fewer items are actively transferring) and never exceeds the configured total.

## Units

The value is integer **KiB/s**. wget gets `--limit-rate=<n>k` and curl `--limit-rate <n>k` (both 1024-based), rsync gets a bare `<n>` (its native KiB unit; no suffix, for compatibility with rsync < 3.1).

## Backward compatibility

With no limit configured (the default), every accessor returns `None` and `realize_args` adds nothing — the spawned command lines are byte-identical to before. No new dependencies; Python 2.7 / 3.3+ clean.

## Tests

Adds `seesaw/bandwidth_test.py` and new cases in `seesaw/externalprocess_test.py` covering the math (division, floor, 0/unlimited, string-typed config values), the per-tool injection, the no-double-injection guards, and rsync `--bwlimit` normalization (space form, equals form, absent slot).

## Companion

ArchiveTeam/warrior-dockerfile companion PR adds `DOWNLOAD_BWLIMIT` / `UPLOAD_BWLIMIT` environment-variable seeding for these settings.

Closes #160.
