### PR TITLE
Fix the 500 when the web interface password contains a colon

### DIFF
--- a/seesaw/web_util.py
+++ b/seesaw/web_util.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import re
 
 import tornado
@@ -20,14 +21,20 @@ class BaseWebAdminHandler(tornado.web.RequestHandler):
             if pattern.match(self.request.uri):
                 return
 
+        username = ''
+        password = ''
+
         auth_header = self.request.headers.get('Authorization')
         if auth_header and auth_header.startswith('Basic '):
-            auth_decoded = base64.b64decode(auth_header[6:].encode('ascii')).decode('ascii')
-            username, password = auth_decoded.split(':', 2)
-            # request.basicauth_user, request.basicauth_pass = username, password
-        else:
-            username = ''
-            password = ''
+            try:
+                auth_decoded = base64.b64decode(
+                    auth_header[6:].encode('ascii')).decode('utf-8')
+                # RFC 7617: only the first colon separates the two fields.
+                username, password = auth_decoded.split(':', 1)
+            except (ValueError, UnicodeError, binascii.Error):
+                # Unusable credentials are a failed login, not a 500.
+                username = ''
+                password = ''
 
         if self.application.settings['check_auth'](self.request, username, password):
             return


### PR DESCRIPTION
Fixes ArchiveTeam/warrior-dockerfile#80 reported there, but the handler lives in this repo.

Setting an HTTP password containing a colon makes the web interface return 500. A password of only letters and digits works. The pipelines keep running normally, so uploads continue and the tracker leaderboard keeps climbing while the interface is unreachable — which makes it look like a UI bug rather than an auth one.

Randomly generated passwords hit this often since most generators include  `:` in their symbol set.